### PR TITLE
Update of Update-Modules.ps1

### DIFF
--- a/Update all PowerShell Modules/Update-Modules.ps1
+++ b/Update all PowerShell Modules/Update-Modules.ps1
@@ -6,7 +6,7 @@ function Update-Modules {
 
     #Get all installed modules
     Write-Host "Retrieving all installed modules" -ForegroundColor Green
-    $currentmodules = Get-InstalledModule | Select-Object Name, Version | Sort-Object Name
+    $CurrentModules = Get-InstalledModule | Select-Object Name, Version | Sort-Object Name
 
     #Show status of AllowPrerelease Switch
     if ($AllowPrerelease) {
@@ -17,17 +17,17 @@ function Update-Modules {
     }
        
     #Loop through the installed modules and update them if a newer version is available
-    foreach ($module in $currentmodules) {
-        Write-Host "- Checking for updated version of the $($module.Name) module" -ForegroundColor Green
+    foreach ($Module in $CurrentModules) {
+        Write-Host "- Checking for updated version of the $($Module.Name) module" -ForegroundColor Green
         try {
-            update-module -Name $module.Name -AllowPrerelease:$AllowPrerelease -AcceptLicense -Scope:AllUsers 
+            Update-Module -Name $Module.Name -AllowPrerelease:$AllowPrerelease -AcceptLicense -Scope:AllUsers 
         }
         catch {
-            Write-Host "Error updating $($module.Name)" -ForegroundColor Red
+            Write-Host "Error updating $($Module.Name)" -ForegroundColor Red
         }
 
-        #Retrieve newewst version number and remove old(er) version(s) if any
-        $allversions = Get-InstalledModule -Name $module.Name -AllVersions | Sort-Object PublishedDate -Descending
+        #Retrieve newest version number and remove old(er) version(s) if any
+        $AllVersions = Get-InstalledModule -Name $Module.Name -AllVersions | Sort-Object PublishedDate -Descending
         $MostRecentVersion = $AllVersions[0].Version
         if ($AllVersions.Count -gt 1 ) {
             Foreach ($Version in $AllVersions) {
@@ -45,12 +45,12 @@ function Update-Modules {
     }
 
     #Get the new module versions for comparing them to to previous one if updated
-    $newmodules = Get-InstalledModule | Select-Object Name, Version | Sort-Object Name
+    $NewModules = Get-InstalledModule | Select-Object Name, Version | Sort-Object Name
     Write-Host "`nList of updated modules (if any)" -ForegroundColor Green
-    foreach ($module in $newmodules) {
-        $currentversion = $currentmodules | Where-Object Name -match $module.Name
-        if ($currentversion.Version -notlike $module.version) {
-            Write-Host "- Updated $($module.Name) from version $($currentversion.version) to $($module.version)" -ForegroundColor Green
+    foreach ($Module in $NewModules) {
+        $CurrentVersion = $CurrentModules | Where-Object Name -eq $Module.Name
+        if ($CurrentVersion.Version -notlike $Module.Version) {
+            Write-Host "- Updated $($Module.Name) from version $($CurrentVersion.Version) to $($Module.Version)" -ForegroundColor Green
         }
     }
 }


### PR DESCRIPTION
- some small non-/capital letters stuff

- $CurrentModules | Where-Object Name -eq $Module.Name instead of $CurrentModules | Where-Object Name -match $Module.Name , or you get a result like:

List of updated modules (if any)
- Updated Az from version 8.0.0 2.8.0 1.1.2 4.1.0 1.1.4 3.0.0 1.1.0 2.0.0 1.0.0 1.7.3 3.2.0 2.0.0 2.1.0 1.1.0 1.11.0 4.27.0 3.1.0 3.0.0 1.8.0 1.1.0 1.2.0 1.16.7 1.0.2 1.3.0 1.0.1 1.1.0 3.1.0 1.0.2 1.1.2 1.3.0 2.0.0 1.9.0 4.0.3 5.0.1 2.0.0 2.7.4 4.5.0 2.1.0 1.5.0 1.1.3 1.2.0 1.0.0 3.0.0 1.0.2 1.1.1 1.1.2 3.0.1 1.0.0 4.17.0 1.1.1 3.1.0 1.5.0 1.1.0 1.1.2 1.0.3 5.4.0 1.6.0 1.0.0 1.0.3 1.1.0 6.0.0 1.3.0 1.1.0 1.9.0 3.0.2 1.4.1 3.9.0 1.1.0 1.1.1 4.6.0 1.7.0 2.0.0 1.0.0 1.4.0 1.1.0 2.11.2 to 8.1.0
- Updated Az.Accounts from version 2.8.0 to 2.9.0
- Updated Az.Aks from version 4.1.0 to 4.2.0
- Updated Az.ApplicationInsights from version 2.0.0 to 2.1.0
- Updated Az.Compute from version 4.27.0 to 4.29.0
- Updated Az.CosmosDB from version 1.8.0 to 1.8.2
- Updated Az.DataFactory from version 1.16.7 to 1.16.8
- Updated Az.EventHub from version 2.0.0 to 2.1.0
- Updated Az.KeyVault from version 4.5.0 to 4.6.0
- Updated Az.Network from version 4.17.0 to 4.18.0
- Updated Az.PowerBIEmbedded from version 1.1.2 to 1.2.0
- Updated Az.RecoveryServices from version 5.4.0 to 5.4.1
- Updated Az.Resources from version 6.0.0 to 6.0.1
- Updated Az.Security from version 1.3.0 1.1.0 to 1.3.0
- Updated Az.ServiceBus from version 1.9.0 to 1.10.0
- Updated Az.ServiceFabric from version 3.0.2 to 3.1.0
- Updated Az.Sql from version 3.9.0 1.1.0 to 3.10.0
- Updated Az.StackHCI from version 1.1.1 to 1.3.0
- Updated Az.Storage from version 4.6.0 1.7.0 to 4.7.0